### PR TITLE
fix: handle null content in rich_text fields

### DIFF
--- a/libs/notion-wrapper.js
+++ b/libs/notion-wrapper.js
@@ -224,13 +224,13 @@ function ifThenSet (input, key, output, type, keyOut, trimNull, defaultValue = n
       output[keyOut] = { [type]: { start: newVal } }
     }
   } else if (type === 'rich_text') {
-    // handle null - Notion API requires content to be a string
-    if (newVal === null) {
+    // Notion API needs content to be string, not null/undefined
+    if (!newVal) {
       output[keyOut] = { [type]: [] }
     } else {
       output[keyOut] = {
         [type]: [
-          { type: 'text', text: { content: newVal } }
+          { type: 'text', text: { content: String(newVal) } }
         ]
       }
     }

--- a/libs/notion-wrapper.js
+++ b/libs/notion-wrapper.js
@@ -224,10 +224,15 @@ function ifThenSet (input, key, output, type, keyOut, trimNull, defaultValue = n
       output[keyOut] = { [type]: { start: newVal } }
     }
   } else if (type === 'rich_text') {
-    output[keyOut] = {
-      [type]: [
-        { type: 'text', text: { content: newVal } }
-      ]
+    // handle null - Notion API requires content to be a string
+    if (newVal === null) {
+      output[keyOut] = { [type]: [] }
+    } else {
+      output[keyOut] = {
+        [type]: [
+          { type: 'text', text: { content: newVal } }
+        ]
+      }
     }
   } else if (type === 'multi_select') {
     output[keyOut] = {


### PR DESCRIPTION
## Summary

Fixes the error "content should be a string but null" when the `version` field is null or undefined.

### Problem

When a repository doesn't have a `version` in its package.json, the Notion API throws an error because `rich_text` content must be a string, not null.

### Solution

Modified `ifThenSet()` function in `libs/notion-wrapper.js` to handle falsy values for `rich_text` type:

```javascript
} else if (type === 'rich_text') {
  if (!newVal) {
    output[keyOut] = { [type]: [] }
  } else {
    output[keyOut] = {
      [type]: [
        { type: 'text', text: { content: String(newVal) } }
      ]
    }
  }
}
```

### Changes

- Handle null, undefined, and empty string cases for rich_text
- Use `String()` coercion for type safety

Fixes #26