### PR TITLE
feat: add per-label issue counter columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Last step | Add the database ID to the GitHub Action secrets
 | --- | --- | --- | --- |
 | `github-repository-query` | The GitHub repository query to fetch the repositories to monitor. You can test the query on [GitHub Search] | Yes | |
 | `github-issue-labels`     | Filter the issues counter by labels. Example: `good first issue` | No | |
+| `github-issue-columns`    | Add one Notion column per label with the open issues count for that label. Comma-separated list. Example: `good first issue,triage,stale` | No | |
 | `notion-token`            | The Notion API key to use to update the database | Yes | |
 | `notion-database-id`      | The Notion database ID to update | Yes | |
 | `github-token`            | The GitHub token to use to fetch the repositories | No | `${{github.token}}` |

--- a/action.js
+++ b/action.js
@@ -6,6 +6,7 @@ import { NpmWrapper } from './libs/npm-wrapper.js'
 import { NotionWrapper } from './libs/notion-wrapper.js'
 
 import * as utils from './libs/utils.js'
+import { toGraphqlAlias } from './queries/github-search.js'
 
 export { upsertStatusBoard }
 
@@ -14,6 +15,7 @@ async function upsertStatusBoard ({
   githubToken,
   githubRepositoryQuery,
   githubIssueLabels,
+  githubIssueColumns = [],
   notionToken,
   databaseId,
   options
@@ -31,12 +33,13 @@ async function upsertStatusBoard ({
   const notion = new NotionWrapper({
     auth: notionToken,
     databaseId,
-    logger
+    logger,
+    issueColumns: githubIssueColumns
   })
 
   await notion.prepareDatabase()
 
-  const githubRepos = await github.searchRepositories(githubRepositoryQuery, githubIssueLabels)
+  const githubRepos = await github.searchRepositories(githubRepositoryQuery, githubIssueLabels, githubIssueColumns)
   logger.info('Found %d repositories', githubRepos.length)
 
   const npmPackages = await npm.searchPackages(githubRepos)
@@ -102,7 +105,7 @@ function buildActions ({
     .map(github => ({ github }))
     .map(decorateWith(npmPackagesMap, 'npm'))
     .map(decorateWith(notionLinesMap, 'notion'))
-    .map(convertToAction)
+    .map(item => convertToAction(item, notionClient.issueColumns))
     .filter(removeUnchangedLines.bind(notionClient))
 
   if (!deleteAdditionalRows) {
@@ -152,7 +155,7 @@ function removeUnchangedLines (item) {
   return true
 }
 
-function convertToAction ({ github, npm, notion }) {
+function convertToAction ({ github, npm, notion }, issueColumns = []) {
   // all the fields must be listed here
   let payload = {
     title: github.name,
@@ -182,6 +185,11 @@ function convertToAction ({ github, npm, notion }) {
       packageSizeBytes: npm.manifest.dist.unpackedSize,
       downloads: npm.downloads.downloads
     }
+  }
+
+  for (const label of issueColumns) {
+    const alias = toGraphqlAlias(label)
+    payload[label] = github[alias]?.totalCount
   }
 
   return {

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,12 @@ inputs:
     description: >
       Filter the issues counter by labels. Example: 'bug,enhancement'
     required: false
+  github-issue-columns:
+    description: >
+      Create one Notion column per label with the open issues count for that
+      label. Comma-separated list of labels.
+      Example: 'good first issue,triage,stale'
+    required: false
   github-token:
     description: > 
       Your Github token, it's already available to your Github action.

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ async function main () {
     const githubToken = core.getInput('github-token')
     const githubRepositoryQuery = core.getInput('github-repository-query')
     const githubIssueLabels = core.getInput('github-issue-labels')?.split(',').map(s => s.trim()).filter(e => e)
+    const githubIssueColumns = core.getInput('github-issue-columns')?.split(',').map(s => s.trim()).filter(e => e) || []
 
     const notionToken = core.getInput('notion-token')
     const databaseId = core.getInput('notion-database-id')
@@ -38,6 +39,7 @@ async function main () {
       githubToken,
       githubRepositoryQuery,
       githubIssueLabels,
+      githubIssueColumns,
 
       notionToken,
       databaseId,

--- a/libs/github-wrapper.js
+++ b/libs/github-wrapper.js
@@ -1,6 +1,6 @@
 import * as github from '@actions/github'
 
-import { querySearch } from '../queries/github-search.js'
+import { buildQuery } from '../queries/github-search.js'
 
 class GitHubWrapper {
   constructor ({ auth, logger, options }) {
@@ -9,11 +9,11 @@ class GitHubWrapper {
     this.wrapperOpts = options
   }
 
-  async searchRepositories (searchQuery, issueLabels) {
+  async searchRepositories (searchQuery, issueLabels, issueColumns) {
     const repos = await paginateQuery({
       client: this.octokit,
       logger: this.logger,
-      query: querySearch,
+      query: buildQuery(issueColumns),
       queryName: 'search',
       pageSize: this.wrapperOpts.pageSize,
       variables: {

--- a/libs/notion-wrapper.js
+++ b/libs/notion-wrapper.js
@@ -25,7 +25,7 @@ const COLUMN_LABLES = {
 }
 
 class NotionWrapper {
-  constructor ({ auth, databaseId, logger }) {
+  constructor ({ auth, databaseId, logger, issueColumns = [] }) {
     this.logger = logger
     this.notion = new Client({
       auth,
@@ -40,7 +40,9 @@ class NotionWrapper {
     })
 
     this.databaseId = databaseId
+    this.issueColumns = issueColumns
     this.columnsMapping = null
+    this.issueColumnsMapping = []
   }
 
   async prepareDatabase () {
@@ -53,7 +55,7 @@ class NotionWrapper {
 
     const missingColumns = this._getMissingColumns()
     if (missingColumns.length > 0) {
-      this.logger.info('Adding missing columns: %o', missingColumns)
+      this.logger.info('Adding missing columns: %o', missingColumns.map(c => c.name))
 
       const updatedSchema = await this.notion.databases.update({
         database_id: this.databaseId,
@@ -65,7 +67,7 @@ class NotionWrapper {
 
       this._refreshInternalMapping(Object.values(updatedSchema.properties))
       if (this._getMissingColumns().length > 0) {
-        throw new Error(`Failed to add missing columns: ${missingColumns}`)
+        throw new Error(`Failed to add missing columns: ${missingColumns.map(c => c.name).join(', ')}`)
       }
       this.logger.debug('DB Mapping ready %o', this.columnsMapping)
     } else {
@@ -127,7 +129,7 @@ class NotionWrapper {
   }
 
   toHumanProperties (properties) {
-    return {
+    const result = {
       title: properties[this.columnsMapping.title.name].title[0].plain_text,
       version: properties[this.columnsMapping.version.name].rich_text[0]?.plain_text || undefined,
       stars: properties[this.columnsMapping.stars.name]?.number,
@@ -141,6 +143,14 @@ class NotionWrapper {
       downloads: properties[this.columnsMapping.downloads.name]?.number || undefined,
       topics: properties[this.columnsMapping.topics.name]?.multi_select?.map(x => x.name) || undefined
     }
+
+    for (const mapping of this.issueColumnsMapping) {
+      if (mapping.column) {
+        result[mapping.label] = properties[mapping.column.name]?.number
+      }
+    }
+
+    return result
   }
 
   toNotionProperties (input, { trimNull }) {
@@ -165,6 +175,12 @@ class NotionWrapper {
     ifThenSet(input, 'version', out, 'rich_text', this.columnsMapping.version.id, trimNull)
     ifThenSet(input, 'topics', out, 'multi_select', this.columnsMapping.topics.id, trimNull)
 
+    for (const mapping of this.issueColumnsMapping) {
+      if (mapping.column) {
+        ifThenSet(input, mapping.label, out, 'number', mapping.column.id, trimNull)
+      }
+    }
+
     return out
   }
 
@@ -185,12 +201,24 @@ class NotionWrapper {
       downloads: columns.find(c => c.name === COLUMN_LABLES.downloads),
       topics: columns.find(c => c.name === COLUMN_LABLES.topics)
     }
+
+    this.issueColumnsMapping = this.issueColumns.map(label => ({
+      label,
+      column: columns.find(c => c.name === label)
+    }))
   }
 
   _getMissingColumns () {
-    return Object.entries(this.columnsMapping)
-      .filter(([, value]) => !value) //
+    const staticMissing = Object.entries(this.columnsMapping)
+      .filter(([key, value]) => key !== 'title' && !value) // title is auto-created
       .map(([key]) => DATABASE_TEMPLATE[COLUMN_LABLES[key]])
+      .filter(Boolean)
+
+    const dynamicMissing = this.issueColumnsMapping
+      .filter(m => !m.column)
+      .map(m => buildIssueColumnTemplate(m.label))
+
+    return staticMissing.concat(dynamicMissing)
   }
 
   _thottle (fn, input) {
@@ -205,6 +233,14 @@ class NotionWrapper {
 
 export {
   NotionWrapper
+}
+
+function buildIssueColumnTemplate (label) {
+  return {
+    name: label,
+    type: 'number',
+    number: { format: 'number' }
+  }
 }
 
 function ifThenSet (input, key, output, type, keyOut, trimNull, defaultValue = null) {

--- a/queries/github-search.js
+++ b/queries/github-search.js
@@ -1,60 +1,81 @@
+export function buildQuery (issueColumns = []) {
+  const columnFields = issueColumns.map((label) => {
+    const alias = toGraphqlAlias(label)
+    return `${alias}: issues(states: OPEN, labels: ["${escapeGraphqlString(label)}"]) { totalCount }`
+  }).join('\n            ')
 
-export const querySearch = `#graphql
-  query ($searchQuery: String!, $first: Int!, $after: String, $issueLabels: [String!]) {
-    search(query: $searchQuery, type: REPOSITORY, first: $first, after: $after) {
-      pageInfo {
-        endCursor
-        hasNextPage
-      }
-      nodes {
-        ... on Repository {
-          name
-          description
-          owner { login }
-          stargazerCount
-          url
-          isArchived
-          isFork
-          issues(states: OPEN, labels: $issueLabels) {
-            totalCount
-          }
-          pullRequests(states: OPEN) {
-            totalCount
-          }
-          repositoryTopics(first: 100) {
-            nodes {
-              ... on RepositoryTopic {
-                topic {
-                  name
-                }
-              }
-            }
-          }
-          releases(first:1) {
-            nodes {
-              publishedAt
-              tagName
-            }
-          }
-          defaultBranchRef {
+  const columnFieldsIndented = columnFields
+    ? `\n            ${columnFields}\n          `
+    : ''
+
+  return `#graphql
+    query ($searchQuery: String!, $first: Int!, $after: String, $issueLabels: [String!]) {
+      search(query: $searchQuery, type: REPOSITORY, first: $first, after: $after) {
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+        nodes {
+          ... on Repository {
             name
-            target {
-              ... on Commit {
-                history(first:1) {
-                  nodes {
-                    committedDate
+            description
+            owner { login }
+            stargazerCount
+            url
+            isArchived
+            isFork
+            issues(states: OPEN, labels: $issueLabels) {
+              totalCount
+            }            ${columnFieldsIndented}
+            pullRequests(states: OPEN) {
+              totalCount
+            }
+            repositoryTopics(first: 100) {
+              nodes {
+                ... on RepositoryTopic {
+                  topic {
+                    name
                   }
                 }
               }
             }
-          }
-          pkg: object(expression: "HEAD:package.json") {
-            ... on Blob {
-              text
+            releases(first:1) {
+              nodes {
+                publishedAt
+                tagName
+              }
+            }
+            defaultBranchRef {
+              name
+              target {
+                ... on Commit {
+                  history(first:1) {
+                    nodes {
+                      committedDate
+                    }
+                  }
+                }
+              }
+            }
+            pkg: object(expression: "HEAD:package.json") {
+              ... on Blob {
+                text
+              }
             }
           }
         }
       }
     }
-  }
-`
+  `
+}
+
+export function toGraphqlAlias (label) {
+  const camel = label
+    .replace(/[^a-zA-Z0-9]+(.)?/g, (_, chr) => chr ? chr.toUpperCase() : '')
+  const safe = camel.length === 0 || !/^[a-zA-Z_]/.test(camel) ? `x${camel}` : camel
+  return safe.charAt(0).toLowerCase() + safe.slice(1)
+}
+
+function escapeGraphqlString (value) {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
+}

--- a/test-self-check.mjs
+++ b/test-self-check.mjs
@@ -1,0 +1,28 @@
+import assert from 'node:assert/strict'
+
+import { buildQuery, toGraphqlAlias } from './queries/github-search.js'
+
+// alias sanitization: spaces, hyphens, leading digit, emoji, empty
+assert.equal(toGraphqlAlias('good first issue'), 'goodFirstIssue')
+assert.equal(toGraphqlAlias('needs-triage'), 'needsTriage')
+assert.equal(toGraphqlAlias('1.0'), 'x10')
+assert.equal(toGraphqlAlias('bug'), 'bug')
+assert.equal(toGraphqlAlias(''), 'x')
+assert.equal(toGraphqlAlias('🚨 urgent'), 'urgent')
+
+// query: empty columns preserves the original shape
+const empty = buildQuery()
+assert.ok(empty.includes('issues(states: OPEN, labels: $issueLabels)'))
+assert.ok(!empty.includes(': issues(states: OPEN, labels: ['))
+
+// query: each label becomes an aliased field
+const q = buildQuery(['good first issue', 'triage', 'stale'])
+assert.ok(q.includes('goodFirstIssue: issues(states: OPEN, labels: ["good first issue"])'))
+assert.ok(q.includes('triage: issues(states: OPEN, labels: ["triage"])'))
+assert.ok(q.includes('stale: issues(states: OPEN, labels: ["stale"])'))
+
+// query: a quote in a label must be escaped
+const escaped = buildQuery(['he said "hi"'])
+assert.ok(escaped.includes('labels: ["he said \\"hi\\""]'))
+
+console.log('self-check ok')


### PR DESCRIPTION
Closes #6

Adds a new \`github-issue-columns\` input that creates one Notion column per label with the open issues count for that label.

## Example

```yaml
with:
  github-issue-columns: 'good first issue,triage,stale'
```

This adds three number columns to the Notion database, one per label, with the open issues count for that label on each repository row.

## How

- The GraphQL query is generated dynamically with one aliased \`issues\` field per label (e.g. \`goodFirstIssue: issues(states: OPEN, labels: [\"good first issue\"]) { totalCount }\`).
- The Notion wrapper already has an auto-schema flow (\`prepareDatabase\`); it now also creates number columns for each label on the fly, and reads/writes them alongside the static fields.
- \`github-issue-labels\` (filter for the total Issues count) is unchanged for backwards compatibility.